### PR TITLE
Remove SCSS IntelliSense due to performance issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.2
+
+- **Remove SCSS Intellisense**
+
 ## 1.0.1
 
 - **Add require cartride resolve**

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ See an extension that you think should be included or removed? Create an [issue]
 
 - [Beautify](https://marketplace.visualstudio.com/items?itemName=HookyQR.beautify): Beautify code in place for VS Code
 
-- [SCSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-scss): Advanced autocompletion and refactoring support for SCSS
-
 - [JavaScript Patterns Snippets](https://marketplace.visualstudio.com/items?itemName=nikhilkumar80.js-patterns-snippets): Snippets for Visual Studio Code with good solutions for regular problems in JavaScript
 
 - [Subtle Match Brackets](https://marketplace.visualstudio.com/items?itemName=rafamel.subtle-brackets): Underlined matching brackets and more

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "finico.quickOpenSelection",
         "formulahendry.auto-rename-tag",
         "HookyQR.beautify",
-        "mrmlnc.vscode-scss",
         "nikhilkumar80.js-patterns-snippets",
         "rafamel.subtle-brackets",
         "robinbentley.sass-indented",


### PR DESCRIPTION
Fixes issue #4
This plugin hasn't been updated in 3 years and is causing CPU spikes.